### PR TITLE
Add spanish translation (ballo-P)

### DIFF
--- a/src/main/resources/messages/messages_es.properties
+++ b/src/main/resources/messages/messages_es.properties
@@ -1,0 +1,40 @@
+general.save=Guardar
+general.apply=Aplicar
+general.cancel=Cancelar
+
+menu.file=Archivo
+menu.file.new=Crear
+menu.file.new.song=Canción
+menu.file.new.voicebank=Librería Vocal
+menu.file.openSong=Abrir Canción...
+menu.file.openVoicebank=Abrir Librería Vocal...
+menu.file.saveFileAs=Guardar Como...
+menu.edit=Editar
+menu.view=Ver
+menu.view.zoomIn=Aumentar el Zoom
+menu.view.zoomOut=Reducir el Zoom
+menu.project=Proyecto
+menu.project.properties=Propiedades
+menu.plugins=Plugins
+menu.plugins.openPlugin=Abrir Plugin...
+menu.plugins.recentPlugins=Plugins Recientes
+menu.help=Ayuda
+menu.help.about=Acerca De
+
+song.mode=Modo
+song.quantization=Cuantización
+song.render=Reproducir
+song.exportWav=Exportar Archivo WAV
+
+voice.name=Nombre
+voice.author=Autor
+
+properties.projectName=Nombre del Proyecto
+properties.outputFile=Archivo de Salida
+properties.flags=Flags
+properties.resampler=Resampler
+properties.wavtool=Wavtool
+properties.voicebank=Librería Vocal
+properties.tempo=Tempo
+
+dialog.closeWithoutSaving=No Guardar


### PR DESCRIPTION
Below comments are written by contributor:
"""
(Spanish is my mother-tongue)
- I chose to use the term "Librería Vocal" (vocal library) rather than "Banco de Voz" (voicebank)
- "Flags, resampler, wavtool, tempo, plugins, zoom" are left as is, no need to translate them. (tempo, plugins, zoom are common to see in software despite being English words, and flags,resampler,wavtool are UTAU-specific and translating them would confuse others and over-complicate things)
- menu.file.new is translated as "Crear" (create) (gender neutral) rather than "Nuevo" or "Nueva" (new) to avoid the "misgendering" of words inside the submenu

"""