### PR TITLE
Play note in voicebank using the resampler

### DIFF
--- a/src/main/java/com/utsusynth/utsu/controller/voicebank/VoicebankController.java
+++ b/src/main/java/com/utsusynth/utsu/controller/voicebank/VoicebankController.java
@@ -13,6 +13,7 @@ import com.utsusynth.utsu.controller.EditorController;
 import com.utsusynth.utsu.controller.common.MenuItemManager;
 import com.utsusynth.utsu.controller.common.UndoService;
 import com.utsusynth.utsu.controller.song.BulkEditorController.BulkEditorType;
+import com.utsusynth.utsu.engine.Engine;
 import com.utsusynth.utsu.files.voicebank.VoicebankWriter;
 import com.utsusynth.utsu.model.voicebank.VoicebankContainer;
 import com.utsusynth.utsu.view.voicebank.*;
@@ -60,6 +61,8 @@ public class VoicebankController implements EditorController, Localizable {
     private final StatusBar statusBar;
     private final VoicebankWriter voicebankWriter;
 
+    // Engine to play resampler
+    private final Engine engine;
     @FXML // fx:id="pitchPane"
     private ScrollPane pitchPane; // Value injected by FXMLLoader
 
@@ -94,7 +97,8 @@ public class VoicebankController implements EditorController, Localizable {
             UndoService undoService,
             MenuItemManager menuItemManager,
             StatusBar statusBar,
-            VoicebankWriter voicebankWriter) {
+            VoicebankWriter voicebankWriter,
+            Engine engine) {
         this.voicebank = voicebankContainer;
         this.voiceEditor = voiceEditor;
         this.pitchEditor = pitchEditor;
@@ -105,6 +109,7 @@ public class VoicebankController implements EditorController, Localizable {
         this.statusBar = statusBar;
         this.voicebankWriter = voicebankWriter;
 
+        this.engine = engine;
     }
 
     // Provide setup for other frontend song management.
@@ -207,6 +212,10 @@ public class VoicebankController implements EditorController, Localizable {
                 anchorBottom.getChildren().add(configEditor.getControlElement());
                 anchorBottom.getChildren().add(configEditor.getChartElement());
                 bindLabelsAndControlBars(configEditor.getControlElement());
+            }
+            @Override
+            public void playLyricWithResampler(LyricConfigData lyricData, boolean modulation) {
+                engine.playLyricWithResampler(lyricData,modulation);
             }
         });
 

--- a/src/main/java/com/utsusynth/utsu/controller/voicebank/VoicebankController.java
+++ b/src/main/java/com/utsusynth/utsu/controller/voicebank/VoicebankController.java
@@ -13,7 +13,6 @@ import com.utsusynth.utsu.controller.EditorController;
 import com.utsusynth.utsu.controller.common.MenuItemManager;
 import com.utsusynth.utsu.controller.common.UndoService;
 import com.utsusynth.utsu.controller.song.BulkEditorController.BulkEditorType;
-import com.utsusynth.utsu.engine.Engine;
 import com.utsusynth.utsu.files.voicebank.VoicebankWriter;
 import com.utsusynth.utsu.model.voicebank.VoicebankContainer;
 import com.utsusynth.utsu.view.voicebank.*;

--- a/src/main/java/com/utsusynth/utsu/controller/voicebank/VoicebankController.java
+++ b/src/main/java/com/utsusynth/utsu/controller/voicebank/VoicebankController.java
@@ -13,6 +13,7 @@ import com.utsusynth.utsu.controller.EditorController;
 import com.utsusynth.utsu.controller.common.MenuItemManager;
 import com.utsusynth.utsu.controller.common.UndoService;
 import com.utsusynth.utsu.controller.song.BulkEditorController.BulkEditorType;
+import com.utsusynth.utsu.engine.Engine;
 import com.utsusynth.utsu.files.voicebank.VoicebankWriter;
 import com.utsusynth.utsu.model.voicebank.VoicebankContainer;
 import com.utsusynth.utsu.view.voicebank.*;
@@ -25,10 +26,7 @@ import javafx.scene.Node;
 import javafx.scene.control.*;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.input.KeyCode;
-import javafx.scene.input.KeyCodeCombination;
-import javafx.scene.input.KeyEvent;
-import javafx.scene.input.MouseEvent;
+import javafx.scene.input.*;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.shape.Line;
@@ -107,6 +105,7 @@ public class VoicebankController implements EditorController, Localizable {
         this.menuItemManager = menuItemManager;
         this.statusBar = statusBar;
         this.voicebankWriter = voicebankWriter;
+
     }
 
     // Provide setup for other frontend song management.
@@ -314,6 +313,12 @@ public class VoicebankController implements EditorController, Localizable {
         if (new KeyCodeCombination(KeyCode.SPACE).match(keyEvent)) {
             configEditor.playSound(); // Does nothing if config editor not loaded.
             return true;
+        } else if (new KeyCodeCombination( KeyCode.SPACE, KeyCombination.CONTROL_DOWN).match(keyEvent)) {
+            configEditor.playSoundWithResampler(true);
+            return true;
+        } else if (new KeyCodeCombination( KeyCode.SPACE, KeyCombination.SHIFT_DOWN, KeyCombination.CONTROL_DOWN).match(keyEvent)) {
+            configEditor.playSoundWithResampler(false);
+            return true;
         } else {
             // No need to override default key behavior.
             return false;
@@ -353,7 +358,10 @@ public class VoicebankController implements EditorController, Localizable {
             } catch (Exception e) {
                 Platform.runLater(
                         () -> statusBar.setStatus(
-                                "Error: Unable to load voicebank: " + file.getName()));
+                        //        "Error: Unable to load voicebank: " + file.getName()
+                            MessageFormat.format(
+                                localizer.getMessage("status.unableToLoadVoicebank"), file.getName())
+                        ));
             }
         }).start();
     }

--- a/src/main/java/com/utsusynth/utsu/engine/Engine.java
+++ b/src/main/java/com/utsusynth/utsu/engine/Engine.java
@@ -9,6 +9,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.Optional;
 
+import com.utsusynth.utsu.common.data.LyricConfigData;
 import com.utsusynth.utsu.files.CacheManager;
 import com.utsusynth.utsu.files.PreferencesManager;
 import com.utsusynth.utsu.files.PreferencesManager.CacheMode;
@@ -86,6 +87,39 @@ public class Engine {
 
     public void setWavtoolPath(File wavtoolPath) {
         wavtoolPath = wavtoolPath;
+    }
+
+    /**
+     * Play a note from VoiceBank, using the resampler
+     * @param lyricData
+     * @param modulation if true, modulation=100, else modulation=0
+     */
+    public void playLyricWithResampler(LyricConfigData lyricData, boolean modulation) {
+        File renderedNote;
+        Note note= new Note();
+        note.setLyric(lyricData.getLyric());
+        note.setNoteNum(60);
+        note.setDuration(2000); // unnecessary
+        note.setModulation(modulation ? 100:0);
+        renderedNote = cacheManager.createNoteCache();
+        resampler.resampleNote(
+                getResamplerPath(),
+                note,
+                2000.0,
+                lyricData,
+                renderedNote,
+                "",
+                120);
+
+        try {
+            Media media = new Media(renderedNote.toURI().toString());
+            mediaPlayer = new MediaPlayer(media);
+            mediaPlayer.setOnReady(() -> {
+                mediaPlayer.play();
+            });
+        } catch(IllegalArgumentException e) {
+            System.out.println("Not correct parameter for file");
+        }
     }
 
     /**

--- a/src/main/java/com/utsusynth/utsu/engine/Resampler.java
+++ b/src/main/java/com/utsusynth/utsu/engine/Resampler.java
@@ -65,12 +65,16 @@ public class Resampler {
     }
 
 
-    // engine.getResamplerPath(),
-    //                    note,
-    //                    2.0,
-    //                    curConfig,
-    //                    renderedNote,
-    //                    "");
+    /**
+     * Play a note based on Note and LyricConfigData, using the resampler
+     * @param resamplerPath Path to the resampler
+     * @param note A Note object
+     * @param noteLength Note length, in ms
+     * @param config a LyricConfigData, as present on LyricConfigEditor
+     * @param outputFile File to write the result
+     * @param pitchString Pitch changes
+     * @param tempo Tempo in BPM at which pitch changes are established
+     */
     public void resampleNote(
             File resamplerPath,
             Note note,
@@ -85,11 +89,11 @@ public class Resampler {
         String consonantVelocity = Double.toString(note.getVelocity());
         String flags = note.getNoteFlags().isEmpty() ? "?" : note.getNoteFlags();
         String offset = Double.toString(config.offsetProperty().getValue());
-        double consonantLength = config.consonantProperty().getValue(); // TODO: Cutoff?
+        double consonantLength = config.consonantProperty().getValue();
         String cutoff = Double.toString(config.cutoffProperty().getValue());
         String intensity = Integer.toString(note.getIntensity());
-        String modulation = Integer.toString(note.getModulation()); // TODO: Set this song-wide?
-        String tempoString = "T" + tempo; // TODO: Override with note tempo.
+        String modulation = Integer.toString(note.getModulation());
+        String tempoString = "T" + tempo;
 
         // Call resampler.
         runner.runProcess(
@@ -98,7 +102,7 @@ public class Resampler {
                 outputFilePath,
                 pitch,
                 consonantVelocity,
-                flags.isEmpty() ? "?" : flags, // Uses placeholder value if there are no flags.
+                flags.isEmpty() ? "?" : flags,
                 offset,
                 Double.toString(noteLength),
                 Double.toString(consonantLength),

--- a/src/main/java/com/utsusynth/utsu/engine/Resampler.java
+++ b/src/main/java/com/utsusynth/utsu/engine/Resampler.java
@@ -2,6 +2,7 @@ package com.utsusynth.utsu.engine;
 
 import java.io.File;
 import com.google.inject.Inject;
+import com.utsusynth.utsu.common.data.LyricConfigData;
 import com.utsusynth.utsu.common.utils.PitchUtils;
 import com.utsusynth.utsu.files.AssetManager;
 import com.utsusynth.utsu.files.FileNameFixer;
@@ -62,6 +63,52 @@ public class Resampler {
                 tempo,
                 pitchString);
     }
+
+
+    // engine.getResamplerPath(),
+    //                    note,
+    //                    2.0,
+    //                    curConfig,
+    //                    renderedNote,
+    //                    "");
+    public void resampleNote(
+            File resamplerPath,
+            Note note,
+            double noteLength,
+            LyricConfigData config,
+            File outputFile,
+            String pitchString,
+            int tempo) {
+        String inputFilePath = fileNameFixer.getFixedName(config.getPathToFile().getAbsolutePath());
+        String outputFilePath = outputFile.getAbsolutePath();
+        String pitch = PitchUtils.noteNumToPitch(note.getNoteNum());
+        String consonantVelocity = Double.toString(note.getVelocity());
+        String flags = note.getNoteFlags().isEmpty() ? "?" : note.getNoteFlags();
+        String offset = Double.toString(config.offsetProperty().getValue());
+        double consonantLength = config.consonantProperty().getValue(); // TODO: Cutoff?
+        String cutoff = Double.toString(config.cutoffProperty().getValue());
+        String intensity = Integer.toString(note.getIntensity());
+        String modulation = Integer.toString(note.getModulation()); // TODO: Set this song-wide?
+        String tempoString = "T" + tempo; // TODO: Override with note tempo.
+
+        // Call resampler.
+        runner.runProcess(
+                resamplerPath.getAbsolutePath(),
+                inputFilePath,
+                outputFilePath,
+                pitch,
+                consonantVelocity,
+                flags.isEmpty() ? "?" : flags, // Uses placeholder value if there are no flags.
+                offset,
+                Double.toString(noteLength),
+                Double.toString(consonantLength),
+                cutoff,
+                intensity,
+                modulation,
+                tempoString,
+                pitchString);
+    }
+
 
     void resampleSilence(File resamplerPath, File outputFile, double duration) {
         String desiredLength = Double.toString(duration + 1);

--- a/src/main/java/com/utsusynth/utsu/view/song/note/Note.java
+++ b/src/main/java/com/utsusynth/utsu/view/song/note/Note.java
@@ -24,6 +24,8 @@ import javafx.scene.input.MouseButton;
 import javafx.scene.layout.StackPane;
 import javafx.scene.shape.Rectangle;
 
+// This represent the note on screen
+
 public class Note implements Comparable<Note> {
     private final StackPane layout;
     private final Rectangle note;

--- a/src/main/java/com/utsusynth/utsu/view/voicebank/LyricConfigCallback.java
+++ b/src/main/java/com/utsusynth/utsu/view/voicebank/LyricConfigCallback.java
@@ -7,4 +7,7 @@ public interface LyricConfigCallback {
     void recordAction(Runnable redoAction, Runnable undoAction);
 
     void refreshEditor(LyricConfigData lyricData);
+
+    void playLyricWithResampler(LyricConfigData lyricData, boolean modulation);
+
 }

--- a/src/main/java/com/utsusynth/utsu/view/voicebank/LyricConfigEditor.java
+++ b/src/main/java/com/utsusynth/utsu/view/voicebank/LyricConfigEditor.java
@@ -12,7 +12,6 @@ import com.utsusynth.utsu.engine.Engine;
 import com.utsusynth.utsu.engine.Resampler;
 import com.utsusynth.utsu.files.CacheManager;
 import com.utsusynth.utsu.files.voicebank.SoundFileReader;
-import com.utsusynth.utsu.model.song.Note;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Side;
@@ -40,9 +39,6 @@ public class LyricConfigEditor {
     private final SoundFileReader soundFileReader;
     private final Localizer localizer;
 
-    private final Resampler resampler;
-    private final Engine engine;
-    private final CacheManager cacheManager;
 
     private Optional<LyricConfigData> configData;
     private LyricConfigCallback model;
@@ -58,16 +54,10 @@ public class LyricConfigEditor {
     @Inject
     public LyricConfigEditor(
             SoundFileReader soundFileReader,
-            Localizer localizer,
-            Resampler resampler,
-            Engine engine,
-            CacheManager cacheManager
+            Localizer localizer
     ) {
         this.soundFileReader = soundFileReader;
         this.localizer = localizer;
-        this.resampler = resampler;
-        this.engine = engine;
-        this.cacheManager = cacheManager;
         // Initialize with dummy data.
         configData = Optional.empty();
         background = new GridPane();
@@ -253,39 +243,13 @@ public class LyricConfigEditor {
         if (!configData.isPresent()) {
             return;
         }
-        File renderedNote;
-        LyricConfigData curConfigData = configData.get();
 
-        Note note= new Note();
-        note.setLyric(curConfigData.getLyric());
-        note.setNoteNum(60);
-        note.setDuration(2000); // unnecessary
-        note.setModulation(modulation ? 100:0);
-        renderedNote = cacheManager.createNoteCache();
-        resampler.resampleNote(
-                    engine.getResamplerPath(),
-                    note,
-                    2000.0,
-                    curConfigData,
-                    renderedNote,
-                    "",
-                    120);
-
-        try {
-            Media media = new Media(renderedNote.toURI().toString());
-            mediaPlayer = new MediaPlayer(media);
-            mediaPlayer.setOnReady(() -> {
-                mediaPlayer.play();
-            });
-        } catch(IllegalArgumentException e) {
-            System.out.println("Not correct parameter for file");
-        }
+        model.playLyricWithResampler(configData.get(), modulation);
     }
     public void playSound() {
         if (!configData.isPresent()) {
             return;
         }
-        //System.out.println("Path to play: "+configData.get().getPathToFile().toURI().toString());
         Media media = new Media(configData.get().getPathToFile().toURI().toString());
         mediaPlayer = new MediaPlayer(media);
         mediaPlayer.setOnReady(() -> {

--- a/src/main/java/com/utsusynth/utsu/view/voicebank/LyricConfigEditor.java
+++ b/src/main/java/com/utsusynth/utsu/view/voicebank/LyricConfigEditor.java
@@ -11,10 +11,8 @@ import com.utsusynth.utsu.common.i18n.Localizer;
 import com.utsusynth.utsu.engine.Engine;
 import com.utsusynth.utsu.engine.Resampler;
 import com.utsusynth.utsu.files.CacheManager;
-import com.utsusynth.utsu.files.PreferencesManager;
 import com.utsusynth.utsu.files.voicebank.SoundFileReader;
 import com.utsusynth.utsu.model.song.Note;
-import com.utsusynth.utsu.model.voicebank.LyricConfig;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Side;
@@ -44,7 +42,6 @@ public class LyricConfigEditor {
 
     private final Resampler resampler;
     private final Engine engine;
-    private final PreferencesManager preferencesManager;
     private final CacheManager cacheManager;
 
     private Optional<LyricConfigData> configData;
@@ -64,14 +61,12 @@ public class LyricConfigEditor {
             Localizer localizer,
             Resampler resampler,
             Engine engine,
-            PreferencesManager preferencesManager,
             CacheManager cacheManager
     ) {
         this.soundFileReader = soundFileReader;
         this.localizer = localizer;
         this.resampler = resampler;
         this.engine = engine;
-        this.preferencesManager = preferencesManager;
         this.cacheManager = cacheManager;
         // Initialize with dummy data.
         configData = Optional.empty();
@@ -247,22 +242,25 @@ public class LyricConfigEditor {
     public Group getControlElement() {
         return controlBars;
     }
+
+    /**
+     * Play a note using the resampler
+     * The note is played using pitch C4 (midi 60) during 2 seconds
+     *
+     * @param modulation if false, modulation on resampler is set to 0
+     */
     public void playSoundWithResampler(boolean modulation) {
         if (!configData.isPresent()) {
-            System.out.println("No info");
             return;
         }
-        System.out.println("Parsing");
-
+        File renderedNote;
         LyricConfigData curConfigData = configData.get();
+
         Note note= new Note();
         note.setLyric(curConfigData.getLyric());
         note.setNoteNum(60);
-        note.setDuration(1000);
+        note.setDuration(2000); // unnecessary
         note.setModulation(modulation ? 100:0);
-
-        File renderedNote;
-
         renderedNote = cacheManager.createNoteCache();
         resampler.resampleNote(
                     engine.getResamplerPath(),
@@ -273,8 +271,6 @@ public class LyricConfigEditor {
                     "",
                     120);
 
-//        System.out.println(renderedNote.toString());
-//        System.out.println(new File(renderedNote.toString() ).isFile());
         try {
             Media media = new Media(renderedNote.toURI().toString());
             mediaPlayer = new MediaPlayer(media);
@@ -289,7 +285,7 @@ public class LyricConfigEditor {
         if (!configData.isPresent()) {
             return;
         }
-        System.out.println("Path to play: "+configData.get().getPathToFile().toURI().toString());
+        //System.out.println("Path to play: "+configData.get().getPathToFile().toURI().toString());
         Media media = new Media(configData.get().getPathToFile().toURI().toString());
         mediaPlayer = new MediaPlayer(media);
         mediaPlayer.setOnReady(() -> {
@@ -369,7 +365,7 @@ public class LyricConfigEditor {
         yAxis.setAutoRanging(false);
         yAxis.setLowerBound(-maxAmplitude);
         yAxis.setUpperBound(maxAmplitude);
-        yAxis.setTickUnit(maxAmplitude / 5);
+        yAxis.setTickUnit(maxAmplitude / 5.0);
         yAxis.setSide(Side.RIGHT);
         yAxis.setOpacity(0);
         yAxis.setTickLabelsVisible(false);

--- a/src/main/resources/messages/messages_en.properties
+++ b/src/main/resources/messages/messages_en.properties
@@ -42,7 +42,7 @@ menu.plugins.recentPlugins=Recent Plugins
 menu.help=Help
 menu.help.about=About
 
-song.play=Play
+voice.play=Play
 song.quantization=Quantization
 song.openCurrentVoicebank=Open Voicebank
 song.note.vibrato=Vibrato
@@ -130,3 +130,6 @@ dialog.saveWarning=Do you want to save your changes to "{0}"?
 dialog.closeWithoutSaving=Don't Save
 
 status.loadedVoicebank=Loaded voicebank: {0}
+status.unableToLoadVoicebank=Error - Unable to load voicebank: {0}
+voice.playWithResampler=Play with Resampler
+voice.playWithResamplerNoModulation=Play with Resampler (No modulation)

--- a/src/main/resources/messages/messages_es.properties
+++ b/src/main/resources/messages/messages_es.properties
@@ -9,7 +9,6 @@ menu.file.new.song=Canción
 menu.file.new.voicebank=Librería Vocal
 menu.file.openSong=Abrir Canción...
 menu.file.openVoicebank=Abrir Librería Vocal...
-menu.file.openVoicebank.select=Seleccionar Directorio de la Librería Vocal...
 menu.file.saveFileAs=Guardar Como...
 menu.file.exportWav=Exportar Archivo WAV...
 menu.file.preferences=Preferencias...
@@ -43,7 +42,7 @@ menu.plugins.recentPlugins=Plugins Recientes
 menu.help=Ayuda
 menu.help.about=Acerca De
 
-song.play=Reproducir
+voice.play=Reproducir
 song.quantization=Cuantización
 song.openCurrentVoicebank=Abrir Librería Vocal
 song.note.vibrato=Vibrato
@@ -131,3 +130,6 @@ dialog.saveWarning=¿Quiere guardar sus cambios a "{0}"?
 dialog.closeWithoutSaving=No Guardar
 
 status.loadedVoicebank=Librería de voz cargada: {0}
+status.unableToLoadVoicebank=Error - Unable to load voicebank: {0}
+voice.playWithResampler=Reproducir con resampler
+voice.playWithResamplerNoModulation=Play with Resampler (No modulation)

--- a/src/main/resources/messages/messages_fr_FR.properties
+++ b/src/main/resources/messages/messages_fr_FR.properties
@@ -42,7 +42,7 @@ menu.plugins.recentPlugins=Plugins Récents
 menu.help=Aide
 menu.help.about=A Propos
 
-song.play=Play
+voice.play=Play
 song.quantization=Quantification
 song.openCurrentVoicebank=Ouvrir cette Banque Vocale
 song.note.vibrato=Vibrato
@@ -130,3 +130,6 @@ dialog.saveWarning=Do you want to save your changes to "{0}"?
 dialog.closeWithoutSaving=Ne pas Sauvegarder
 
 status.loadedVoicebank=Loaded voicebank: {0}
+status.unableToLoadVoicebank=Error - Unable to load voicebank: {0}
+voice.playWithResampler=Play with Resampler
+voice.playWithResamplerNoModulation=Play with Resampler (No modulation)

--- a/src/main/resources/messages/messages_hy.properties
+++ b/src/main/resources/messages/messages_hy.properties
@@ -42,7 +42,7 @@ menu.plugins.recentPlugins=Վերջին փլագինները
 menu.help=Օգնություն
 menu.help.about=Մեր մասին
 
-song.play=Նվագարկել
+voice.play=Նվագարկել
 song.quantization=Քվանտացում
 song.openCurrentVoicebank=Բացել ձայնային բանկը
 song.note.vibrato=Վիբրատո
@@ -130,3 +130,6 @@ dialog.saveWarning=ցանկանու՞մ եք փոփոխություններ պա
 dialog.closeWithoutSaving=Մի պահեք
 
 status.loadedVoicebank=Loaded voicebank: {0}
+status.unableToLoadVoicebank=Error - Unable to load voicebank: {0}
+voice.playWithResampler=Play with Resampler
+voice.playWithResamplerNoModulation=Play with Resampler (No modulation)

--- a/src/main/resources/messages/messages_in.properties
+++ b/src/main/resources/messages/messages_in.properties
@@ -42,7 +42,7 @@ menu.plugins.recentPlugins=Plugin Terbaru
 menu.help=Bantuan
 menu.help.about=Tentang
 
-song.play=Play
+voice.play=Play
 song.quantization=Kuantisasi
 song.openCurrentVoicebank=Buka Pustaka Suara
 song.note.vibrato=Vibrato
@@ -130,3 +130,6 @@ dialog.saveWarning=Do you want to save your changes to "{0}"?
 dialog.closeWithoutSaving=Jangan Simpan
 
 status.loadedVoicebank=Loaded voicebank: {0}
+status.unableToLoadVoicebank=Error - Unable to load voicebank: {0}
+voice.playWithResampler=Play with Resampler
+voice.playWithResamplerNoModulation=Play with Resampler (No modulation)

--- a/src/main/resources/messages/messages_it.properties
+++ b/src/main/resources/messages/messages_it.properties
@@ -43,7 +43,7 @@ menu.plugins.recentPlugins=Plugin Recenti
 menu.help=Aiuto
 menu.help.about=Info
 
-song.play=Play
+voice.play=Play
 song.quantization=Quantità
 song.openCurrentVoicebank=Apri Voicebank
 song.note.vibrato=Vibrato
@@ -131,3 +131,6 @@ dialog.saveWarning=Do you want to save your changes to "{0}"?
 dialog.closeWithoutSaving=Non Salvare
 
 status.loadedVoicebank=Loaded voicebank: {0}
+status.unableToLoadVoicebank=Error - Unable to load voicebank: {0}
+voice.playWithResampler=Play with Resampler
+voice.playWithResamplerNoModulation=Play with Resampler (No modulation)

--- a/src/main/resources/messages/messages_ja.properties
+++ b/src/main/resources/messages/messages_ja.properties
@@ -42,7 +42,7 @@ menu.plugins.recentPlugins=最近使ったプラグイン
 menu.help=ヘルプ
 menu.help.about=UTSUについて
 
-song.play=再生
+voice.play=再生
 song.quantization=クオンタイズ
 song.openCurrentVoicebank=原音を開く
 song.note.vibrato=ビブラート
@@ -130,3 +130,6 @@ dialog.saveWarning=「{0}」は変更されています。保存しますか？
 dialog.closeWithoutSaving=変更を破棄
 
 status.loadedVoicebank=「{0}」をロードしました
+status.unableToLoadVoicebank=Error - Unable to load voicebank: {0}
+voice.playWithResampler=Play with Resampler
+voice.playWithResamplerNoModulation=Play with Resampler (No modulation)

--- a/src/main/resources/messages/messages_pt_BR.properties
+++ b/src/main/resources/messages/messages_pt_BR.properties
@@ -42,7 +42,7 @@ menu.plugins.recentPlugins=Plugins Recentes
 menu.help=Ajuda
 menu.help.about=Sobre
 
-song.play=Reproduzir
+voice.play=Reproduzir
 song.quantization=Quantização
 song.openCurrentVoicebank=Abrir Banco de Voz
 song.note.vibrato=Vibrato
@@ -130,3 +130,6 @@ dialog.saveWarning=Você deseja salvar suas alterações para "{0}"?
 dialog.closeWithoutSaving=Não Salvar
 
 status.loadedVoicebank=Loaded voicebank: {0}
+status.unableToLoadVoicebank=Error - Unable to load voicebank: {0}
+voice.playWithResampler=Reproduzir com Resampler
+voice.playWithResamplerNoModulation=Play with Resampler (No modulation)

--- a/src/main/resources/messages/messages_ru.properties
+++ b/src/main/resources/messages/messages_ru.properties
@@ -42,7 +42,7 @@ menu.plugins.recentPlugins=Недавние плагины
 menu.help=Помощь
 menu.help.about=Об нас
 
-song.play=Играть
+voice.play=Играть
 song.quantization=Квантование
 song.openCurrentVoicebank=Открыть голосовойбанк
 song.note.vibrato=Вибрато
@@ -130,3 +130,6 @@ dialog.saveWarning=Вы хотите сохранить изменения в {0
 dialog.closeWithoutSaving=Не сохранять
 
 status.loadedVoicebank=Loaded voicebank: {0}
+status.unableToLoadVoicebank=Error - Unable to load voicebank: {0}
+voice.playWithResampler=Play with Resampler
+voice.playWithResamplerNoModulation=Play with Resampler (No modulation)

--- a/src/main/resources/messages/messages_zh_CN.properties
+++ b/src/main/resources/messages/messages_zh_CN.properties
@@ -42,7 +42,7 @@ menu.plugins.recentPlugins=最近使用的插件
 menu.help=帮助
 menu.help.about=关于
 
-song.play=播放
+voice.play=播放
 song.quantization=量化
 song.openCurrentVoicebank=打开音源
 song.note.vibrato=颤音
@@ -130,3 +130,6 @@ dialog.saveWarning=是否保存更改为"{0}"?
 dialog.closeWithoutSaving=不保存
 
 status.loadedVoicebank=加载音轨: {0}
+status.unableToLoadVoicebank=Error - Unable to load voicebank: {0}
+voice.playWithResampler=Play with Resampler
+voice.playWithResamplerNoModulation=Play with Resampler (No modulation)

--- a/src/main/resources/messages/messages_zh_TW.properties
+++ b/src/main/resources/messages/messages_zh_TW.properties
@@ -42,7 +42,7 @@ menu.plugins.recentPlugins=最近使用的插件
 menu.help=說明
 menu.help.about=關於
 
-song.play=Play
+voice.play=Play
 song.quantization=量化
 song.openCurrentVoicebank=開啟聲音資料庫
 song.note.vibrato=Vibrato
@@ -130,3 +130,6 @@ dialog.saveWarning=Do you want to save your changes to "{0}"?
 dialog.closeWithoutSaving=不要儲存
 
 status.loadedVoicebank=Loaded voicebank: {0}
+status.unableToLoadVoicebank=Error - Unable to load voicebank: {0}
+voice.playWithResampler=Play with Resampler
+voice.playWithResamplerNoModulation=Play with Resampler (No modulation)


### PR DESCRIPTION
A feature that miss much is set  the consonant and offset time listening to the resampler output,  because allows to create a better loop for vowels. So, this patch implements some changes VoiceBankcontroller, LyricConfigEditor and Resampler to play the notes on voicebank using the resampler, using fixed settings(C4, 2 seconds). Uses the same logic of playSound(), so it shouldn't be hard to check.
Changes on UI:
* Two extra items on contextual menu over the sample chart: play with resampler and play with resampler (no modulation)
* Ctrl+Space on voicebank stage:   play with resample
* Shift+Ctrl+Space on voicebank stage:   play with resample (no modulation)

I tested on some voicebank and allows a very fast workflow to fix them to macres.